### PR TITLE
Unify WebContent log prefix and subsystem

### DIFF
--- a/Source/WebKit/Scripts/generate-derived-log-sources.py
+++ b/Source/WebKit/Scripts/generate-derived-log-sources.py
@@ -93,7 +93,7 @@ def generate_message_receiver_implementations_file(log_messages, log_messages_re
             if category == "Default":
                 file.write("    auto osLogPointer = OS_LOG_DEFAULT;\n")
             else:
-                file.write("    auto osLog = adoptOSObject(os_log_create(\"com.apple.WebKit.WebContent\", \"" + category + "\"));\n")
+                file.write("    auto osLog = adoptOSObject(os_log_create(\"com.apple.WebKit\", \"" + category + "\"));\n")
                 file.write("    auto osLogPointer = osLog.get();\n")
 
             file.write("    os_log_with_type(osLogPointer, " + os_log_type + ", \"[PID=%d]: \"" + format_string)

--- a/Source/WebKit/Shared/LogStream.cpp
+++ b/Source/WebKit/Shared/LogStream.cpp
@@ -85,7 +85,7 @@ void LogStream::logOnBehalfOfWebContent(std::span<const uint8_t> logSubsystem, s
 
     // Use '%{public}s' in the format string for the preprocessed string from the WebContent process.
     // This should not reveal any redacted information in the string, since it has already been composed in the WebContent process.
-    os_log_with_type(osLogPointer, static_cast<os_log_type_t>(logType), "WP[%d] %{public}s", m_pid, byteCast<char>(nullTerminatedLogString).data());
+    os_log_with_type(osLogPointer, static_cast<os_log_type_t>(logType), "[PID=%d] %{public}s", m_pid, byteCast<char>(nullTerminatedLogString).data());
 }
 
 void LogStream::setup(IPC::StreamServerConnectionHandle&& serverConnection, LogStreamIdentifier logStreamIdentifier, CompletionHandler<void(IPC::Semaphore& streamWakeUpSemaphore, IPC::Semaphore& streamClientWaitSemaphore)>&& completionHandler)


### PR DESCRIPTION
#### 78ea1c437eab7fe9a3d7e9f111fffe281ebda54b
<pre>
Unify WebContent log prefix and subsystem
<a href="https://bugs.webkit.org/show_bug.cgi?id=292381">https://bugs.webkit.org/show_bug.cgi?id=292381</a>
<a href="https://rdar.apple.com/150453365">rdar://150453365</a>

Reviewed by NOBODY (OOPS!).

We should use the same prefix and subsystem for WebContent logs that are being forwarded to the UI process through
the log hook, as well as for those that are being directly sent over CoreIPC. We have not migrated all WebKit logs
to the efficient version yet, so there are still some that are being picked up by the log hook.

* Source/WebKit/Scripts/generate-derived-log-sources.py:
(generate_message_receiver_implementations_file):
* Source/WebKit/Shared/LogStream.cpp:
(WebKit::LogStream::logOnBehalfOfWebContent):
</pre>